### PR TITLE
Add .gitattributes to highlight .spy files like .py files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.spy linguist-language=Python


### PR DESCRIPTION
Similar to https://github.com/spylang/spy/pull/126.

Tell GitHub (and other tools) to apply Python syntax highlighting to `.spy` files to make them more readable.

Compare https://github.com/ambv/spy-examples/blob/main/perlin/perlin.spy with https://github.com/hugovk/spy-examples/blob/test/perlin/thing.py

It might take a bit time after merge for it to take effect, I think GitHub caches the pages.